### PR TITLE
masson/core/iptables: fixed install

### DIFF
--- a/core/iptables/install.coffee.md
+++ b/core/iptables/install.coffee.md
@@ -11,15 +11,13 @@ The package "iptables" is installed.
       @service
         timeout: -1
         name: 'iptables'
+        startup: startup
+        action: action
       @system.discover (err, status, os) ->
         @service
           if: -> (os.type in ['redhat','centos']) and os.release[0] is '7'
           header: 'Iptable Service'
           name: 'iptables-services'
-      @service.startup
-        name: 'iptables'
-        startup: startup
-        action: action
 
 ## Log
 


### PR DESCRIPTION
I need `/bin/ryba install` to turn off iptables on my machines so I used the following config:

```
iptables:
  action: 'stop'
  startup: false
```
  
But I need my iptables to be stopped now not on the next reboot so I noticed that the action was not triggered in nikita's `@service.index`.

Anyway this commit fixed my problem but I am not sure it is the proper way to do it.

Please let me know if I misunderstood something.