### PR TITLE
Update install.coffee.md

### DIFF
--- a/core/openldap_server/install.coffee.md
+++ b/core/openldap_server/install.coffee.md
@@ -179,7 +179,7 @@ discovered at runtime based on the OS release.
             header: 'Suffix'
             unless_exec: """
             ldapsearch -Y EXTERNAL -H ldapi:/// \
-              -b "olcDatabase={2}hdb,cn=config" \
+              -b "olcDatabase={2}#{bdb},cn=config" \
             | grep -E "olcSuffix: #{openldap_server.suffix}"
             """
             cmd: """


### PR DESCRIPTION
Fix for Centos6 : Replacing hard coded value : {2}hdb, by parameter : {2}#{bdb}