### PR TITLE
Add cluster argument to the run command

### DIFF
--- a/lib/commands/run.coffee
+++ b/lib/commands/run.coffee
@@ -42,6 +42,7 @@ module.exports = (params, config, callback) ->
       for service in node.services
         service = s.service service.cluster, service.service
         continue if params.modules and multimatch(service.module, params.modules).length is 0
+        continue if params.cluster and multimatch(service.cluster, params.cluster).length is 0
         instance = array_get service.instances, (instance) -> instance.node.id is node.id
         if service.commands[params.command]
           for module in service.commands[params.command]

--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -39,6 +39,9 @@ module.exports = (processOrArgv, callback) ->
         ,
           name: 'resume', shortcut: 'r', type: 'boolean'
           description: 'Resume from previous run'
+        ,
+          name: 'cluster', shortcut: 'c', type: 'array'
+          description: 'Limit to a list of clusters'
         ]
     # Merge default parameters with discovered parameters and user parameters
     mixme.mutate params, commands: commands, config.params


### PR DESCRIPTION
Adds a `--cluster` option to the run command to target specific clusters when using `install`
Note that masson will still try to open a ssh connection to all the nodes in configuration but no services will be installed.